### PR TITLE
feature: override helmchart values using inline path

### DIFF
--- a/examples/helmvalues/site-values.yaml
+++ b/examples/helmvalues/site-values.yaml
@@ -4,7 +4,7 @@ metadata:
   name: site
 global:
   docker_registry: registry.cicd.stg.taco
-helmValues:
+charts:
   - chartName: glance
     chartRef: taco-k8s-v20.07
     override:

--- a/plugin/openinfradev.github.com/v1/helmvaluestransformer/HelmValuesTransformer.go
+++ b/plugin/openinfradev.github.com/v1/helmvaluestransformer/HelmValuesTransformer.go
@@ -7,46 +7,27 @@ import (
 	"errors"
 	"log"
 	"os"
+	"strings"
 
 	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/yaml"
 )
 
 // Override values in HelmReleases
 type plugin struct {
-	Global     map[string]string `json:"global,omitempty" yaml:"global,omitempty"`
-	HelmValues []helmValues      `json:"helmValues,omitempty" yaml:"helmValues,omitempty"`
-	Logger     *log.Logger
+	h      *resmap.PluginHelpers
+	Global map[string]string `json:"global,omitempty" yaml:"global,omitempty"`
+	Charts []ReplacedChart   `json:"charts,omitempty" yaml:"charts,omitempty"`
+	Logger *log.Logger
 }
 
-type helmValues struct {
-	ChartName string            `json:"chartName,omitempty" yaml:"chartName,omitempty"`
-	ChartRef  string            `json:"chartRef,omitempty" yaml:"chartRef,omitempty"`
-	Override  map[string]string `json:"override,omitempty" yaml:"override,omitempty"`
-}
-
-// HelmRelease is a CustomResource for Helm Operator.
-type HelmRelease struct {
-	APIVersion string            `json:"apiVersion" yaml:"apiVersion"`
-	Kind       string            `json:"kind" yaml:"kind"`
-	Metadata   map[string]string `json:"metadata" yaml:"metadata"`
-	Spec       HelmReleaseSpec   `json:"spec" yaml:"spec"`
-}
-
-// HelmReleaseSpec is HelmRelease's spec
-type HelmReleaseSpec struct {
-	Chart           HelmReleaseChart `json:"chart" yaml:"chart"`
-	ReleaseName     string           `json:"releaseName,omitempty" yaml:"releaseName,omitempty"`
-	TargetNamespace string           `json:"targetNamespace,omitempty" yaml:"targetNamespace,omitempty"`
-	Values          interface{}      `json:"values" yaml:"values"`
-}
-
-// HelmReleaseChart is HelmRelease's Chart definition.
-type HelmReleaseChart struct {
-	Git  string `json:"git" yaml:"git"`
-	Path string `json:"path" yaml:"path"`
-	Ref  string `json:"ref" yaml:"ref"`
+// ReplacedChart is including target information and chart values to override
+type ReplacedChart struct {
+	ChartName string                 `json:"chartName,omitempty" yaml:"chartName,omitempty"`
+	ChartRef  string                 `json:"chartRef,omitempty" yaml:"chartRef,omitempty"`
+	Override  map[string]interface{} `json:"override,omitempty" yaml:"override,omitempty"`
 }
 
 //nolint: golint
@@ -54,15 +35,16 @@ type HelmReleaseChart struct {
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	_ *resmap.PluginHelpers, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
+	p.h = h
 	p.Global = nil
-	p.HelmValues = nil
+	p.Charts = nil
 
 	err = yaml.Unmarshal(c, p)
 	if err != nil {
 		return nil
 	}
-	if p.HelmValues == nil {
+	if p.Charts == nil {
 		return errors.New("helmValues is not expected to be nil")
 	}
 	p.Logger = log.New(os.Stdout, "[DEBUG] ", log.Lshortfile)
@@ -72,17 +54,23 @@ func (p *plugin) Config(
 func (p *plugin) Transform(m resmap.ResMap) (err error) {
 
 	helmReleaseGvk := resid.Gvk{Group: "helm.fluxcd.io", Version: "v1", Kind: "HelmRelease"}
-	for _, hv := range p.HelmValues {
+	for _, chart := range p.Charts {
 		// replace references of HelmReleases
-		id := resid.NewResId(helmReleaseGvk, hv.ChartName)
+		id := resid.NewResId(helmReleaseGvk, chart.ChartName)
 		origin, err := m.GetById(id)
 		if err != nil {
 			return err
 		}
 		if origin == nil {
+			p.Logger.Println("Can't find HelmRelease name: " + chart.ChartName)
 			continue
 		}
-		if err := p.replaceChartRef(origin.Map(), hv.ChartRef); err != nil {
+		if err := p.replaceChartRef(origin.Map(), chart.ChartRef); err != nil {
+			return err
+		}
+		overrideResource := p.getResourceFromChart(chart)
+		if err := origin.Patch(overrideResource.Copy()); err != nil {
+			p.Logger.Println("patch error: " + err.Error())
 			return err
 		}
 	}
@@ -90,14 +78,39 @@ func (p *plugin) Transform(m resmap.ResMap) (err error) {
 }
 
 func (p *plugin) replaceChartRef(origin map[string]interface{}, chartRef string) (err error) {
-
-	// TODO: Parse helmRelease into HelmRelease
-
-	// Temporary implement
 	releaseSpec := origin["spec"].(map[string]interface{})
 	chart := releaseSpec["chart"].(map[string]interface{})
 	chart["ref"] = chartRef
-	p.Logger.Println("chart ref changed to: ", chart["ref"]) // DEBUG
-
 	return nil
+}
+
+func (p *plugin) getResourceFromChart(replacedChart ReplacedChart) (r *resource.Resource) {
+	patchMap := map[string]interface{}{}
+
+	for inlinePath, val := range replacedChart.Override {
+		p.createMapFromPaths(patchMap, strings.Split(inlinePath, "."), val)
+	}
+
+	resource := p.h.ResmapFactory().RF().FromMap(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"values": patchMap,
+		},
+	})
+	return resource
+}
+
+// inlinePath is a path string using json dot notation
+// i.e. "conf.ceph.admin_keyring"
+func (p *plugin) createMapFromPaths(chart map[string]interface{}, paths []string, val interface{}) map[string]interface{} {
+	currentPath := paths[0]
+	if len(paths) == 1 {
+		chart[currentPath] = val
+		return chart
+	}
+
+	if chart[currentPath] == nil {
+		chart[currentPath] = map[string]interface{}{}
+	}
+	chart[currentPath] = p.createMapFromPaths(chart[currentPath].(map[string]interface{}), paths[1:], val)
+	return chart
 }


### PR DESCRIPTION
# Related Issues: #8 

# New Features
* Enable to override helm values using inline value path
* examples
```
apiVersion: openinfradev.github.com/v1
kind: HelmValuesTransformer
metadata:
  name: site
charts:
  - chartName: glance
    override:
      conf.ceph.admin_keyring: abcde
      conf.ceph.enabled: true
```

