### PR TITLE
refactor: support map, array types to override chart values

### DIFF
--- a/examples/helmvalues/resources.yaml
+++ b/examples/helmvalues/resources.yaml
@@ -10,6 +10,7 @@ spec:
   releaseName: glance
   targetNamespace: openstack
   values:
+    volumeClaimTemplates: TO_BE_FIXED
     bootstrap:
       enabled: true
       structured:
@@ -31,3 +32,4 @@ spec:
         glance_store:
           rbd_store_pool: images
           rbd_store_user: glance
+

--- a/examples/helmvalues/site-values.yaml
+++ b/examples/helmvalues/site-values.yaml
@@ -6,10 +6,15 @@ global:
   docker_registry: registry.cicd.stg.taco
   admin_keyring: abcdefghijk
   repository: http://helm-chart-repository
+  storageClassName: ceph
 charts:
   - name: glance
     source:
       repository: $(repository)
       version: 1.0.0
     override:
-      conf.ceph.admin_keyring: $(admin_keyring)
+      volumeClaimTemplates: 
+      - metadata:
+          name: elasticsearch-data
+        spec:
+          storageClassName: $(storageClassName)

--- a/plugin/openinfradev.github.com/v1/helmvaluestransformer/HelmValuesTransformer_test.go
+++ b/plugin/openinfradev.github.com/v1/helmvaluestransformer/HelmValuesTransformer_test.go
@@ -231,6 +231,7 @@ global:
   cinder_admin_keyring: opqrstuvwxyz
   docker_registry: sktdev
   image_tag: taco-0.1.0
+  storageClassName: ceph
 charts:
   - name: glance
     source:
@@ -240,6 +241,11 @@ charts:
       conf.ceph.admin_keyring: $(glance_admin_keyring)
       conf.ceph.enabled: true
       images.tags.ks_user: $(docker_registry)/ubuntu-source-heat-engine-stein:$(image_tag)
+      volumeClaimTemplates:
+      - metadata:
+          name: glance-data
+        spec:
+          storageClassName: $(storageClassName)
   - name: cinder
     source:
       repository: http://repository-b:8879
@@ -261,11 +267,12 @@ spec:
   values:
     conf:
       ceph:
-        admin_keyring: TACO_FIXME
+        admin_keyring: TO_BE_FIXED
         enabled: false
     images:
       tags:
-        ks_user: TACO_FIXME
+        ks_user: TO_BE_FIXED
+    volumeClaimTemplates: TO_BE_FIXED
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -281,7 +288,7 @@ spec:
   values:
     conf:
       ceph:
-        admin_keyring: TACO_FIXME
+        admin_keyring: TO_BE_FIXED
         enabled: false
 `)
 	th.AssertActualEqualsExpected(rm, `
@@ -304,6 +311,11 @@ spec:
     images:
       tags:
         ks_user: sktdev/ubuntu-source-heat-engine-stein:taco-0.1.0
+    volumeClaimTemplates:
+    - metadata:
+        name: glance-data
+      spec:
+        storageClassName: ceph
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease


### PR DESCRIPTION
# Improvement
- support array typed value
```apiVersion: openinfradev.github.com/v1
kind: HelmValuesTransformer
metadata:
  name: site
global:
  clusterName: cluster.local
charts:
  - name: glance
    override:
      volumeClaimTemplates:
      - metadata:
          name: elasticsearch-data
        spec:
          prometheus.hosts:
          - lma-prometheus-fed-master.fed.svc.$(clusterName):9090
```
- support map typed value
```apiVersion: openinfradev.github.com/v1
kind: HelmValuesTransformer
metadata:
  name: site
global:
  storageClassName: ceph
charts:
  - name: glance
    override:
      volumeClaimTemplates:
      - metadata:
          name: elasticsearch-data
        spec:
          storageClassName: $(storageClassName)
```