### PR TITLE
minor fix: change splitter to support backslash dot(\.)

### DIFF
--- a/plugin/openinfradev.github.com/v1/helmvaluestransformer/HelmValuesTransformer.go
+++ b/plugin/openinfradev.github.com/v1/helmvaluestransformer/HelmValuesTransformer.go
@@ -43,8 +43,8 @@ type ChartSource struct {
 	Type       string `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
-//nolint: golint
-//noinspection GoUnusedGlobalVariable
+// nolint: golint
+// noinspection GoUnusedGlobalVariable
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
@@ -168,7 +168,8 @@ func (p *plugin) getResourceFromChart(replacedChart ReplacedChart) (r *resource.
 		if err != nil {
 			return nil, err
 		}
-		p.createMapFromPaths(patchMap, strings.Split(inlinePath, "."), newVal)
+		paths := splitButIgnoreEscapedDot(inlinePath, "\uffff")
+		p.createMapFromPaths(patchMap, paths, newVal)
 	}
 
 	resource := p.h.ResmapFactory().RF().FromMap(map[string]interface{}{
@@ -237,4 +238,14 @@ func (p *plugin) replaceGlobalVar(original interface{}) (interface{}, error) {
 		return original, err
 	}
 	return inlineStr, nil
+}
+
+func splitButIgnoreEscapedDot(input, placeholder string) []string {
+	temp := strings.ReplaceAll(input, "\\.", placeholder)
+	parts := strings.Split(temp, ".")
+
+	for i := range parts {
+		parts[i] = strings.ReplaceAll(parts[i], placeholder, ".")
+	}
+	return parts
 }

--- a/plugin/openinfradev.github.com/v1/helmvaluestransformer/HelmValuesTransformer_test.go
+++ b/plugin/openinfradev.github.com/v1/helmvaluestransformer/HelmValuesTransformer_test.go
@@ -232,12 +232,22 @@ global:
   docker_registry: sktdev
   image_tag: taco-0.1.0
   storageClassName: ceph
+  grafanaDomain: grafana.example.com
+  keycloakDomain: keycloak.example.com
+  realms: openinfradev
 charts:
   - name: glance
     source:
       repository: http://repository-a:8879
       version: 1.0.1
     override:
+      grafana\.ini: 
+        server:
+          domain: $(grafanaDomain)
+          root_url: $(grafanaDomain)/grafana
+        auth.generic_oauth:
+          enabled: true
+          auth_url: https://$(keycloakDomain)/auth/realms/$(realms)/protocol/openid-connect/auth
       conf.ceph.admin_keyring: $(glance_admin_keyring)
       conf.ceph.enabled: true
       images.tags.ks_user: $(docker_registry)/ubuntu-source-heat-engine-stein:$(image_tag)
@@ -265,6 +275,7 @@ spec:
   releaseName: glance
   targetNamespace: openstack
   values:
+    grafana.ini:
     conf:
       ceph:
         admin_keyring: TO_BE_FIXED
@@ -309,6 +320,13 @@ spec:
       ceph:
         admin_keyring: abcdefghijklmn
         enabled: true
+    grafana.ini:
+      auth.generic_oauth:
+        auth_url: https://keycloak.example.com/auth/realms/openinfradev/protocol/openid-connect/auth
+        enabled: true
+      server:
+        domain: grafana.example.com
+        root_url: grafana.example.com/grafana
     images:
       tags:
         ks_user: sktdev/ubuntu-source-heat-engine-stein:taco-0.1.0


### PR DESCRIPTION
수정 사항
- 기존 동작
  - override 하위에 key: value 쌍을 명시하여 작성해야 하나 "grafana.ini" 와 같은 점(.)을 가진 키가 그대로 반영되어야 하는 경우에 대해 "grafana", "ini" 와 같이 두개의 키로 분리되어 렌더링 됨
- 수정 동작
  - "\\."을 가진 key에 대해서는 split 하지 않도록 수정